### PR TITLE
Fix for Snow Leopard

### DIFF
--- a/Source/PLSimulator/PLExecutableBinary.m
+++ b/Source/PLSimulator/PLExecutableBinary.m
@@ -36,6 +36,17 @@
 #import <mach-o/loader.h>
 #import <mach-o/fat.h>
 
+// Since Snow Leopard does not have strnlen, naive implementation was added.
+#ifndef MAC_OS_X_VERSION_10_7
+size_t strnlen(register const char *s, size_t maxlen)
+{
+    for (size_t i=0; i<maxlen; i++)
+        if (*s == '\0')
+            return i;
+    return maxlen;
+}
+#endif // MAC_OS_X_VERSION_10_7
+
 /**
  * @internal
  *


### PR DESCRIPTION
Noticed Simulator Bundler does not work on Snow Leopard, because
- a) dlsym(RTLD_DEFAULT, "main") returns NULL,
- b) strnlen(3) is not available on Snow Leopard.

I made NXGetLocalArchInfo() as fallback for a), and added a naive implementation of strnlen for b).
