### PR TITLE
Add support for selecting simulator iOS version in command line.

### DIFF
--- a/Source/Launcher/LauncherSimClient.m
+++ b/Source/Launcher/LauncherSimClient.m
@@ -117,6 +117,18 @@
         }
     }
 
+    /* Use the SDK in command line argument if specified */
+    NSArray *arguments = [[NSProcessInfo processInfo] arguments];
+    if ([arguments count] > 1) {
+        NSString *sdkArg = (NSString *)[arguments objectAtIndex:1];
+        for (PLSimulatorSDK *anSDK in _platform.sdks) {
+            if ([anSDK.canonicalName isEqual: sdkArg]) {
+                sdk = anSDK;
+                break;
+            }
+        }
+    }
+
     /* Load the SDK root */
     if (sdk != nil) {
         sdkRoot = [C(DTiPhoneSimulatorSystemRoot) rootWithSDKVersion: sdk.version];


### PR DESCRIPTION
It can be helpful to load and test the app in different simulator versions.

For example,
`open bundle.app --args iphonesimulator7.0`
